### PR TITLE
Fix vim installation command in JupyterHub Dockerfile

### DIFF
--- a/docker/jupyterhub/Dockerfile.hub
+++ b/docker/jupyterhub/Dockerfile.hub
@@ -8,7 +8,7 @@ RUN apt update && \
     apt-get -y update && \
     apt-get -y upgrade && \
     apt-get -y dist-upgrade && \
-    apt-get -y vim && \
+    apt-get install -y vim && \
     # # Installing sssd-tools (required for authentication)
     apt-get -y install sssd-tools
 


### PR DESCRIPTION
This commit corrects the vim installation command in the JupyterHub Dockerfile from 'apt-get -y vim' to 'apt-get install -y vim' to ensure proper package installation.