### PR TITLE
Add SSSD packages to JupyterHub Dockerfile

### DIFF
--- a/docker/jupyterhub/Dockerfile.hub
+++ b/docker/jupyterhub/Dockerfile.hub
@@ -9,6 +9,7 @@ RUN apt update && \
     apt-get -y upgrade && \
     apt-get -y dist-upgrade && \
     apt-get install -y vim && \
+    apt-get install -y libpam-sss libnss-sss sssd-common pamtester && \
     # # Installing sssd-tools (required for authentication)
     apt-get -y install sssd-tools
 


### PR DESCRIPTION
This commit enhances the JupyterHub Dockerfile by adding the installation of SSSD-related packages (libpam-sss, libnss-sss, sssd-common, pamtester) to support improved authentication mechanisms within the container.