### PR TITLE
Refactor JupyterHub Dockerfile to use Ubuntu base and enhance package…

### DIFF
--- a/docker/jupyterhub/Dockerfile.hub
+++ b/docker/jupyterhub/Dockerfile.hub
@@ -1,25 +1,74 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-FROM quay.io/jupyterhub/jupyterhub:5.3.0-12
+FROM ubuntu:noble
 
-# Update distro to apply security fixes
-RUN apt update && \
-    apt-get -y clean all && \
-    apt-get -y update && \
-    apt-get -y upgrade && \
-    apt-get -y dist-upgrade && \
-    apt-get install -y vim && \
-    apt-get install -y libpam-sss libnss-sss sssd-common pamtester strace && \
-    # # Installing sssd-tools (required for authentication)
-    apt-get -y install sssd-tools
+LABEL maintainer="Statistics Norway"
 
-# Installing jupyterhub packages
-RUN python3 -m pip install dockerspawner>=12.1.0 && \
-    python3 -m pip install psycopg2-binary && \
-    python3 -m pip install jupyterhub_idle_culler
+# System-wide configuration
+SHELL ["/bin/bash", "-c"]
+ENV SHELL="/bin/bash"
+ENV DEBIAN_FRONTEND="noninteractive"
+
+# Set timezone to Oslo
+ENV TZ=Europe/Oslo
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Install system packages and Python
+RUN apt-get update && \
+    apt-get install -y \
+    python3 \
+    python3-pip \
+    python3-dev \
+    python3-venv \
+    curl \
+    wget \
+    git \
+    vim \
+    ca-certificates \
+    locales \
+    nodejs \
+    npm \
+    # SSSD and PAM packages for authentication
+    libpam-sss \
+    libnss-sss \
+    sssd-common \
+    sssd-tools \
+    pamtester \
+    strace \
+    # Additional dependencies
+    build-essential \
+    libffi-dev \
+    libssl-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Configure locale
+RUN locale-gen nb_NO.UTF-8 && \
+    update-locale LANG=nb_NO.UTF-8 && \
+    echo "nb_NO.UTF-8 UTF-8" > /etc/locale.gen && \
+    locale-gen
+
+# Install Node.js (required for configurable-http-proxy)
+RUN npm install -g configurable-http-proxy
+
+# Create jupyterhub user and directories
+RUN useradd -r -m -s /bin/bash jupyterhub && \
+    mkdir -p /srv/jupyterhub /etc/jupyterhub
+
+# Install JupyterHub and related packages (using --break-system-packages for Docker)
+RUN python3 -m pip install --break-system-packages \
+    jupyterhub==5.3.0 \
+    dockerspawner>=12.1.0 \
+    psycopg2-binary \
+    jupyterhub_idle_culler \
+    notebook \
+    jupyterlab
+
+# Set working directory
+WORKDIR /srv/jupyterhub
 
 # copy jupyterhub_config.py to container
-COPY jupyterhub_config.py /srv/jupyterhub
+COPY jupyterhub_config.py /srv/jupyterhub/
 
 # Copy and run database upgrade script during build
 COPY upgrade-db.sh /tmp/upgrade-db.sh
@@ -37,6 +86,15 @@ ENV SSL_KEY=/srv/jupyterhub/secrets/starssb.key
 # Copy startup script that handles database upgrades
 COPY start-jupyterhub.sh /usr/local/bin/start-jupyterhub.sh
 RUN chmod +x /usr/local/bin/start-jupyterhub.sh
+
+# Set proper ownership before switching user
+RUN chown -R jupyterhub:jupyterhub /srv/jupyterhub /data
+
+# Expose JupyterHub port
+EXPOSE 8000 443
+
+# Switch to root for startup script (needed for database operations)
+USER root
 
 # Use our startup script that handles database upgrades
 CMD ["/usr/local/bin/start-jupyterhub.sh"]


### PR DESCRIPTION
… installations

This commit updates the JupyterHub Dockerfile to use an Ubuntu base image, improving the overall environment setup. It includes the installation of essential system packages, Python, and JupyterHub dependencies, while configuring the locale and timezone. Additionally, it creates a dedicated jupyterhub user and sets proper ownership for directories, ensuring a more robust and maintainable container configuration.