### PR TITLE
Update JupyterHub configuration to include additional volume mounts a…

### DIFF
--- a/docker/jupyterhub/docker-compose.yml
+++ b/docker/jupyterhub/docker-compose.yml
@@ -27,6 +27,8 @@ services:
 
       - "/run/sssd:/run/sssd:rw,z"  
 
+      - "/home/jupyterhub/.docker:/root/.docker:ro"
+
     environment:
       # Use the playground image we built
       DOCKER_NOTEBOOK_IMAGE: ${DOCKER_NOTEBOOK_IMAGE}

--- a/docker/jupyterhub/jupyterhub_config.py
+++ b/docker/jupyterhub/jupyterhub_config.py
@@ -26,7 +26,7 @@ c.PAMAuthenticator.admin_groups = {"RBAG_jupyterhub_admins@ssb.no"}
 c.Authenticator.delete_invalid_users = True
 
 # Spawn containers from this image
-c.DockerSpawner.container_image = os.environ["DOCKER_NOTEBOOK_IMAGE"]
+c.DockerSpawner.image = os.environ["DOCKER_NOTEBOOK_IMAGE"]
 
 # JupyterHub requires a single-user instance of the Notebook server, so we
 # default to using the `start-singleuser.sh` script included in the
@@ -63,7 +63,7 @@ c.SystemUserSpawner.host_homedir_format_string = "/ssb/bruker/{username}"
 c.FileContentsManager.always_delete_dir = True
 
 # Remove containers once they are stopped
-c.DockerSpawner.remove_containers = True
+c.DockerSpawner.remove = True
 
 # For debugging arguments passed to spawned containers
 c.DockerSpawner.debug = True


### PR DESCRIPTION
…nd modify spawner settings

This commit adds a read-only volume mount for the Docker configuration, allowing access to the JupyterHub Docker credentials. It also updates the jupyterhub_config.py file to change the DockerSpawner property names for improved clarity and consistency, enhancing the overall configuration of the JupyterHub environment.