### PR TITLE
Refactor JupyterHub spawner settings and timeout configurations

### DIFF
--- a/docker/jupyterhub/jupyterhub_config.py
+++ b/docker/jupyterhub/jupyterhub_config.py
@@ -26,8 +26,9 @@ c.PAMAuthenticator.admin_groups = {"RBAG_jupyterhub_admins@ssb.no"}
 c.Authenticator.delete_invalid_users = True
 
 
-c.Spawner.args = (getattr(c.Spawner, "args", []) or []) + ["--allow-root"]
+c.Spawner.args = ["--allow-root"]
 c.Spawner.http_timeout = 120
+c.Spawner.start_timeout = 120
 
 # Spawn containers from this image
 c.DockerSpawner.image = os.environ["DOCKER_NOTEBOOK_IMAGE"]


### PR DESCRIPTION
This commit updates the jupyterhub_config.py file to simplify the spawner arguments by directly setting them to allow root access. It also introduces explicit timeout settings for HTTP and spawner start processes, enhancing the reliability and performance of the JupyterHub deployment.