### PR TITLE
Update JupyterHub spawner command to allow root access

### DIFF
--- a/docker/jupyterhub/docker-compose.yml
+++ b/docker/jupyterhub/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       # Define the internal network name
       DOCKER_NETWORK_NAME: jupyterhub-network
       # Using this run command (optional)
-      DOCKER_SPAWN_CMD: jupyterhub-singleuser
+      DOCKER_SPAWN_CMD: "jupyterhub-singleuser --allow-root"
       # Other minimal env vars if needed by the config (adjust as needed)
       DATA_VOLUME_CONTAINER: /data # For cookie secret path
       # Should be passed on to jupyterlab instances

--- a/docker/jupyterhub/jupyterhub_config.py
+++ b/docker/jupyterhub/jupyterhub_config.py
@@ -38,7 +38,7 @@ c.DockerSpawner.image = os.environ["DOCKER_NOTEBOOK_IMAGE"]
 # jupyter/docker-stacks *-notebook images as the Docker run command when
 # spawning containers.  Optionally, you can override the Docker run command
 # using the DOCKER_SPAWN_CMD environment variable.
-spawn_cmd = os.environ.get("DOCKER_SPAWN_CMD", "jupyterhub-singleuser")
+spawn_cmd = os.environ.get("DOCKER_SPAWN_CMD", "jupyterhub-singleuser --allow-root")
 
 # 'user: root' must be set so the user container is spawned as root,
 # this allows changes to NB_USER, NB_UID and NB_GID


### PR DESCRIPTION
This commit modifies the DOCKER_SPAWN_CMD in both the docker-compose.yml and jupyterhub_config.py files to include the '--allow-root' option. This change ensures that the JupyterHub spawner can run with root privileges, enhancing compatibility and functionality for user sessions.