### PR TITLE
Fix spawner argument assignment in JupyterHub configuration

### DIFF
--- a/docker/jupyterhub/jupyterhub_config.py
+++ b/docker/jupyterhub/jupyterhub_config.py
@@ -26,7 +26,7 @@ c.PAMAuthenticator.admin_groups = {"RBAG_jupyterhub_admins@ssb.no"}
 c.Authenticator.delete_invalid_users = True
 
 
-c.Spawner.args = ["--allow-root"]
+c.DockerSpawner.args = ["--allow-root"]
 c.Spawner.http_timeout = 120
 c.Spawner.start_timeout = 120
 


### PR DESCRIPTION
This commit updates the jupyterhub_config.py file to correct the assignment of the spawner argument from `c.Spawner.args` to `c.DockerSpawner.args`. This change ensures that the DockerSpawner is properly configured to allow root access, maintaining the intended functionality of the JupyterHub deployment.