### PR TITLE
Refactor JupyterHub Docker configuration to use standard spawner command

### DIFF
--- a/docker/jupyterhub/Dockerfile.lab
+++ b/docker/jupyterhub/Dockerfile.lab
@@ -480,9 +480,11 @@ ENV npm_config_registry=https://registry.npmjs.org/
 # Expose port
 EXPOSE 8888
 
-# Copy the startup script
-COPY start-singleuser.sh /usr/local/bin/start-singleuser.sh
-RUN chmod +x /usr/local/bin/start-singleuser.sh
+# Remove the custom startup script usage
+# Comment out or remove these lines:
+# COPY start-singleuser.sh /usr/local/bin/start-singleuser.sh
+# RUN chmod +x /usr/local/bin/start-singleuser.sh
+# CMD ["/usr/local/bin/start-singleuser.sh"]
 
-# Use our custom startup script
-CMD ["/usr/local/bin/start-singleuser.sh"]
+# Use the standard jupyterhub-singleuser command
+CMD ["jupyterhub-singleuser"]


### PR DESCRIPTION
This commit removes the custom startup script from the Dockerfile and updates the CMD to use the standard 'jupyterhub-singleuser' command. Additionally, the jupyterhub_config.py file is modified to correct the DockerSpawner configuration, enabling user switching and enhancing the environment variable management for improved container functionality.