### PR TITLE
Update JupyterHub Dockerfile to configure NSS for SSSD integration

### DIFF
--- a/docker/jupyterhub/Dockerfile.lab
+++ b/docker/jupyterhub/Dockerfile.lab
@@ -451,6 +451,13 @@ RUN chmod u-w  /opt/conda/share/jupyter/lab/extensions
 USER root
 RUN apt-get update && apt-get install -y gosu && rm -rf /var/lib/apt/lists/*
 
+
+# Make NSS use SSSD for passwd/group lookups so id/whoami can resolve names
+RUN sed -i 's/^passwd:.*/passwd:     files sss systemd/' /etc/nsswitch.conf && \
+    sed -i 's/^group:.*/group:      files sss systemd/'  /etc/nsswitch.conf && \
+    sed -i 's/^shadow:.*/shadow:     files/'             /etc/nsswitch.conf
+
+
 # Set up proxy configuration
 ENV https_proxy=http://proxy.ssb.no:3128
 ENV no_proxy=nexus.ssb.no,git-adm.ssb.no,i.test.ssb.no,i.ssb.no,i.qa.ssb.no,data.ssb.no,github.com,api.github.com,codeload.github.com


### PR DESCRIPTION
This commit modifies the Dockerfile to update the NSS configuration, enabling SSSD for passwd and group lookups. This change ensures that user identity resolution works correctly within the JupyterHub environment, enhancing user management capabilities.