### PR TITLE
Enhance JupyterHub Docker configuration with client-state fixes and s…

### DIFF
--- a/docker/jupyterhub/Dockerfile.lab
+++ b/docker/jupyterhub/Dockerfile.lab
@@ -179,7 +179,6 @@ RUN R CMD javareconf -e && \
     R -e "install.packages('arrow', dependencies=FALSE, repos='${CRAN}')" && \
     R -e "install.packages('leaflet', dependencies=TRUE, repos='${CRAN}')" && \
     R -e "install.packages('getPass', dependencies=TRUE, repos='${CRAN}')" && \
-    R -e "install.packages('googleCloudStorageR', dependencies=TRUE, repos='${CRAN}')" && \
     R -e "install.packages('DT', dependencies=TRUE, repos='${CRAN}')" && \
     R -e "install.packages('rjwsacruncher', dependencies=TRUE, repos='${CRAN}')" && \
     R -e "install.packages('sf', dependencies=TRUE, repos='${CRAN}')" && \
@@ -387,14 +386,49 @@ RUN pipx install nox && \
 RUN pip install dash
 
 RUN jupyter labextension list
-# Ensure JupyterLab 4.x using the provided script
-RUN jupyter labextension disable @jupyterlab/docmanager-extension:download && \
-    jupyter labextension disable @jupyterlab/filebrowser-extension:download && \
-    jupyter labextension disable @jupyterlab/extensionmanager-extension && \
-    jupyter labextension disable "@jupyterlab/apputils-extension:announcements"  && \
-    jupyter labextension disable jupyterlab-dash  && \
+
+# ---------------- JupyterLab client-state fixes ----------------
+# Front-end: stop auto-restore + common cluster pollers; then rebuild Lab
+RUN set -eux; \
+    jupyter labextension disable @jupyterlab/docmanager-extension:download || true; \
+    jupyter labextension disable @jupyterlab/filebrowser-extension:download || true; \
+    jupyter labextension disable @jupyterlab/extensionmanager-extension || true; \
+    jupyter labextension disable "@jupyterlab/apputils-extension:announcements" || true; \
+    jupyter labextension disable "@jupyterlab/apputils-extension:layout" || true;  \
+    jupyter labextension disable jupyterlab-dash || true; \
+    # Common "clusters" poller plugins (adjust if your plugin id differs)
+    jupyter labextension disable "@dask/dask-labextension:plugin" || true; \
+    jupyter labextension disable "@dask/gateway-extension:plugin" || true; \
+    jupyter labextension disable "jupyterlab-kubernetes:plugin" || true; \
     jupyter lab build
+
 RUN jupyter lab --version
+
+# Workspaces cannot be disabled via CLI; do it via page_config.json
+RUN mkdir -p /opt/conda/etc/jupyter/labconfig && \
+    cat > /opt/conda/etc/jupyter/labconfig/page_config.json <<'JSON'
+{
+  "workspacesDisabled": true,
+  "disabledExtensions": [
+    "@jupyterlab/apputils-extension:layout"
+  ]
+}
+JSON
+
+# Server-side: disable back-end counterparts for common cluster pollers (safe no-ops if missing)
+RUN mkdir -p /opt/conda/etc/jupyter/jupyter_server_config.d && \
+    cat > /opt/conda/etc/jupyter/jupyter_server_config.d/disable_clusters.json <<'JSON'
+{
+  "ServerApp": {
+    "jpserver_extensions": {
+      "dask_labextension": false,
+      "dask_gateway": false,
+      "jupyterlab_kubernetes": false
+    }
+  }
+}
+JSON
+# ---------------------------------------------------------------
 
 # Set template version for ssb-project-cli
 ENV STAT_TEMPLATE_DEFAULT_REFERENCE="1.1.9"
@@ -426,13 +460,7 @@ COPY ./kernels/python3 /opt/conda/share/jupyter/kernels/python3/
 RUN chmod +x /opt/conda/share/jupyter/kernels/python3/python.sh
 RUN chmod +x /opt/conda/share/jupyter/kernels/ir/r.sh
 
-# System Jupyter Server config (JSON drop-in)
-RUN mkdir -p /opt/conda/etc/jupyter/jupyter_server_config.d
-COPY ./jupyter_notebook_extra_config.json /opt/conda/etc/jupyter/jupyter_server_config.d/jupyter_notebook_extra_config.json
-RUN chmod 0644 /opt/conda/etc/jupyter/jupyter_server_config.d/jupyter_notebook_extra_config.json
-
-
-#trying to fix websockets issue
+# trying to fix websockets issue and adding runtime dir inside of the container
 RUN mkdir -p /tmp/jupyter-runtime && chmod 1777 /tmp/jupyter-runtime
 
 # Remove duplicate Python lib

--- a/docker/jupyterhub/jupyterhub_config.py
+++ b/docker/jupyterhub/jupyterhub_config.py
@@ -135,3 +135,20 @@ c.DockerSpawner.environment.update({
     "JUPYTER_RUNTIME_DIR": "/tmp/jupyter-runtime",
     "JUPYTER_PLATFORM_DIRS": "1",
 })
+# -------------------------------------------------------------------
+# Extra args to enforce single-user server config across all spawns
+# -------------------------------------------------------------------
+c.Spawner.args = [
+    "--ServerApp.default_url=/lab/workspaces/lab?reset"
+    "--ServerApp.shutdown_no_activity_timeout=28800",
+    "--ServerApp.tornado_settings={\"static_cache_max_age\":0}",
+    "--ServerApp.log_level=INFO",
+    "--MappingKernelManager.cull_idle_timeout=3600",
+    "--MappingKernelManager.cull_interval=120",
+    "--MappingKernelManager.cull_connected=False",
+    "--MappingKernelManager.cull_busy=False",
+    "--TerminalManager.cull_inactive_timeout=3600",
+    "--TerminalManager.cull_interval=120",
+    "--FileContentsManager.always_delete_dir=True",
+    "--ContentsManager.allow_hidden=True"
+]


### PR DESCRIPTION
…erver args

This commit updates the JupyterHub Dockerfile to implement client-state fixes by disabling specific JupyterLab extensions and configuring the Jupyter runtime directory. Additionally, it introduces extra server arguments in jupyterhub_config.py to enforce single-user server configurations, manage kernel culling, and adjust logging settings, improving the overall performance and stability of the JupyterHub environment.