### PR TITLE
Add hub-control-panel-same-tab labextension to JupyterHub Dockerfile

### DIFF
--- a/docker/jupyterhub/Dockerfile.lab
+++ b/docker/jupyterhub/Dockerfile.lab
@@ -387,6 +387,26 @@ RUN pip install dash
 
 RUN jupyter labextension list
 
+# Install tiny labextension to open Hub Control Panel in same tab
+WORKDIR /opt/jupyter-ext/hub-control-panel-same-tab
+COPY ./labextensions/hub-control-panel-same-tab /opt/jupyter-ext/hub-control-panel-same-tab
+RUN npm ci || npm install && \
+    npm run build && \
+    jupyter labextension develop . --overwrite
+
+# Disable unwanted extensions and build Lab once
+RUN set -eux; \
+    jupyter labextension disable @jupyterlab/docmanager-extension:download || true; \
+    jupyter labextension disable @jupyterlab/filebrowser-extension:download || true; \
+    jupyter labextension disable @jupyterlab/extensionmanager-extension || true; \
+    jupyter labextension disable "@jupyterlab/apputils-extension:announcements" || true; \
+    jupyter labextension disable "@jupyterlab/apputils-extension:layout" || true; \
+    jupyter labextension disable jupyterlab-dash || true; \
+    # (any other disables) \
+    jupyter lab build
+
+WORKDIR ${WORKSPACE_DIR}
+
 # ---------------- JupyterLab client-state fixes ----------------
 # Front-end: stop auto-restore + common cluster pollers; then rebuild Lab
 RUN set -eux; \

--- a/docker/jupyterhub/Dockerfile.lab
+++ b/docker/jupyterhub/Dockerfile.lab
@@ -392,7 +392,7 @@ WORKDIR /opt/jupyter-ext/hub-control-panel-same-tab
 COPY ./labextensions/hub-control-panel-same-tab /opt/jupyter-ext/hub-control-panel-same-tab
 RUN npm ci || npm install && \
     npm run build && \
-    jupyter labextension develop . --overwrite
+    jupyter labextension install . --no-build
 
 # Disable unwanted extensions and build Lab once
 RUN set -eux; \
@@ -408,7 +408,7 @@ RUN set -eux; \
 WORKDIR ${WORKSPACE_DIR}
 
 # ---------------- JupyterLab client-state fixes ----------------
-# Front-end: stop auto-restore + common cluster pollers; then rebuild Lab
+# Front-end: stop auto-restore + common cluster pollers (already built once above)
 RUN set -eux; \
     jupyter labextension disable @jupyterlab/docmanager-extension:download || true; \
     jupyter labextension disable @jupyterlab/filebrowser-extension:download || true; \
@@ -416,11 +416,9 @@ RUN set -eux; \
     jupyter labextension disable "@jupyterlab/apputils-extension:announcements" || true; \
     jupyter labextension disable "@jupyterlab/apputils-extension:layout" || true;  \
     jupyter labextension disable jupyterlab-dash || true; \
-    # Common "clusters" poller plugins (adjust if your plugin id differs)
     jupyter labextension disable "@dask/dask-labextension:plugin" || true; \
     jupyter labextension disable "@dask/gateway-extension:plugin" || true; \
-    jupyter labextension disable "jupyterlab-kubernetes:plugin" || true; \
-    jupyter lab build
+    jupyter labextension disable "jupyterlab-kubernetes:plugin" || true;
 
 RUN jupyter lab --version
 

--- a/docker/jupyterhub/labextensions/hub-control-panel-same-tab/package.json
+++ b/docker/jupyterhub/labextensions/hub-control-panel-same-tab/package.json
@@ -9,7 +9,7 @@
     "extension": true
   },
   "scripts": {
-    "build": "webpack",
+    "build": "rimraf lib && tsc -p tsconfig.json",
     "clean": "rimraf lib build"
   },
   "devDependencies": {
@@ -27,6 +27,7 @@
     "@jupyterlab/application": ">=4.4.7 <5",
     "@jupyterlab/mainmenu": ">=4.4.7 <5"
   },
-  "main": "lib/index.js"
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts"
 }
 

--- a/docker/jupyterhub/labextensions/hub-control-panel-same-tab/package.json
+++ b/docker/jupyterhub/labextensions/hub-control-panel-same-tab/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "hub-control-panel-same-tab",
+  "version": "0.1.0",
+  "description": "Open JupyterHub Control Panel in same tab",
+  "license": "BSD-3-Clause",
+  "author": "SSB",
+  "private": true,
+  "jupyterlab": {
+    "extension": true
+  },
+  "scripts": {
+    "build": "webpack",
+    "clean": "rimraf lib build"
+  },
+  "devDependencies": {
+    "@jupyterlab/builder": "^4.2.0",
+    "@types/node": "^20.11.0",
+    "rimraf": "^5.0.5",
+    "ts-loader": "^9.5.1",
+    "typescript": "^5.4.0",
+    "webpack": "^5.91.0",
+    "webpack-cli": "^5.1.4"
+  },
+  "dependencies": {
+    "@jupyterlab/application": "^4.2.0",
+    "@jupyterlab/coreutils": "^6.2.0"
+  },
+  "main": "lib/index.js"
+}
+

--- a/docker/jupyterhub/labextensions/hub-control-panel-same-tab/package.json
+++ b/docker/jupyterhub/labextensions/hub-control-panel-same-tab/package.json
@@ -14,6 +14,7 @@
   },
   "devDependencies": {
     "@jupyterlab/application": "4.4.7",
+    "@jupyterlab/mainmenu": "4.4.7",
     "@jupyterlab/builder": "^4.2.0",
     "@types/node": "^20.11.0",
     "rimraf": "^5.0.5",
@@ -23,7 +24,8 @@
     "webpack-cli": "^5.1.4"
   },
   "peerDependencies": {
-    "@jupyterlab/application": ">=4.4.7 <5"
+    "@jupyterlab/application": ">=4.4.7 <5",
+    "@jupyterlab/mainmenu": ">=4.4.7 <5"
   },
   "main": "lib/index.js"
 }

--- a/docker/jupyterhub/labextensions/hub-control-panel-same-tab/package.json
+++ b/docker/jupyterhub/labextensions/hub-control-panel-same-tab/package.json
@@ -13,6 +13,7 @@
     "clean": "rimraf lib build"
   },
   "devDependencies": {
+    "@jupyterlab/application": "4.4.7",
     "@jupyterlab/builder": "^4.2.0",
     "@types/node": "^20.11.0",
     "rimraf": "^5.0.5",
@@ -21,9 +22,8 @@
     "webpack": "^5.91.0",
     "webpack-cli": "^5.1.4"
   },
-  "dependencies": {
-    "@jupyterlab/application": "^4.2.0",
-    "@jupyterlab/coreutils": "^6.2.0"
+  "peerDependencies": {
+    "@jupyterlab/application": ">=4.4.7 <5"
   },
   "main": "lib/index.js"
 }

--- a/docker/jupyterhub/labextensions/hub-control-panel-same-tab/src/index.ts
+++ b/docker/jupyterhub/labextensions/hub-control-panel-same-tab/src/index.ts
@@ -29,9 +29,8 @@ const plugin: JupyterFrontEndPlugin<void> = {
       }
     });
 
-    // Ensure it’s in the File menu, first item under "Hub" group
-    const fileMenu = mainMenu.fileMenu.menu;
-    fileMenu.addItem({ command: cmd, rank: 0 });
+    // Legg det inn i File-menyen som første element i en egen gruppe
+    mainMenu.fileMenu.addGroup([{ command: cmd }], 0);
   }
 };
 

--- a/docker/jupyterhub/labextensions/hub-control-panel-same-tab/src/index.ts
+++ b/docker/jupyterhub/labextensions/hub-control-panel-same-tab/src/index.ts
@@ -1,0 +1,25 @@
+import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
+import { PageConfig } from '@jupyterlab/coreutils';
+
+const plugin: JupyterFrontEndPlugin<void> = {
+  id: 'hub-control-panel-same-tab:plugin',
+  autoStart: true,
+  activate: (app: JupyterFrontEnd) => {
+    const cmd = 'hub:control-panel';
+    // If the command exists, override it to open in same tab
+    if (app.commands.hasCommand(cmd)) {
+      app.commands.addCommand(cmd, {
+        label: 'Hub Control Panel',
+        execute: () => {
+          const hubPrefix = PageConfig.getOption('hubPrefix') || '/hub/';
+          // Navigate in the same tab
+          window.location.assign(`${hubPrefix}home`);
+        }
+      });
+    }
+  }
+};
+
+export default plugin;
+
+

--- a/docker/jupyterhub/labextensions/hub-control-panel-same-tab/src/index.ts
+++ b/docker/jupyterhub/labextensions/hub-control-panel-same-tab/src/index.ts
@@ -1,5 +1,4 @@
 import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
-import { PageConfig } from '@jupyterlab/coreutils';
 
 const plugin: JupyterFrontEndPlugin<void> = {
   id: 'hub-control-panel-same-tab:plugin',
@@ -11,7 +10,19 @@ const plugin: JupyterFrontEndPlugin<void> = {
       app.commands.addCommand(cmd, {
         label: 'Hub Control Panel',
         execute: () => {
-          const hubPrefix = PageConfig.getOption('hubPrefix') || '/hub/';
+          // Read config from the DOM to avoid depending on @jupyterlab/coreutils
+          let hubPrefix = '/hub/';
+          const el = document.getElementById('jupyter-config-data');
+          if (el) {
+            try {
+              const cfg = JSON.parse(el.textContent || '{}');
+              if (cfg && typeof cfg.hubPrefix === 'string') {
+                hubPrefix = cfg.hubPrefix;
+              }
+            } catch {
+              /* ignore parse errors */
+            }
+          }
           // Navigate in the same tab
           window.location.assign(`${hubPrefix}home`);
         }

--- a/docker/jupyterhub/labextensions/hub-control-panel-same-tab/src/index.ts
+++ b/docker/jupyterhub/labextensions/hub-control-panel-same-tab/src/index.ts
@@ -1,36 +1,38 @@
 import { JupyterFrontEnd, JupyterFrontEndPlugin } from '@jupyterlab/application';
-import { IMainMenu } from '@jupyterlab/mainmenu';
 
 const plugin: JupyterFrontEndPlugin<void> = {
   id: 'hub-control-panel-same-tab:plugin',
   autoStart: true,
-  requires: [IMainMenu],
-  activate: (app: JupyterFrontEnd, mainMenu: IMainMenu) => {
-    const cmd = 'hub:control-panel';
-    // Force add/override our command
-    app.commands.addCommand(cmd, {
-      label: 'Hub Control Panel',
-      isEnabled: () => true,
-      execute: () => {
-        let hubPrefix = '/hub/';
-        const el = document.getElementById('jupyter-config-data');
-        if (el) {
-          try {
-            const cfg = JSON.parse(el.textContent || '{}');
-            if (cfg && typeof cfg.hubPrefix === 'string') {
-              hubPrefix = cfg.hubPrefix;
-            }
-          } catch {
-            /* ignore */
-          }
+  activate: (app: JupyterFrontEnd) => {
+    // Finn hubPrefix fra DOM-konfig
+    let hubPrefix = '/hub/';
+    const el = document.getElementById('jupyter-config-data');
+    if (el) {
+      try {
+        const cfg = JSON.parse(el.textContent || '{}');
+        if (cfg && typeof cfg.hubPrefix === 'string') {
+          hubPrefix = cfg.hubPrefix;
         }
-        // same-tab navigation
-        window.location.assign(`${hubPrefix}home`);
+      } catch {
+        /* ignore */
       }
-    });
+    }
 
-    // Legg det inn i File-menyen som første element i en egen gruppe
-    mainMenu.fileMenu.addGroup([{ command: cmd }], 0);
+    // Monkey-patch window.open for å åpne Hub i samme fane
+    const guard = '__hubSameTabPatched__';
+    const w = window as unknown as Record<string, unknown>;
+    if (!w[guard]) {
+      const originalOpen = window.open.bind(window);
+      window.open = ((url: string | URL, target?: string, features?: string) => {
+        const s = typeof url === 'string' ? url : url.toString();
+        if (s.includes(`${hubPrefix}home`)) {
+          window.location.assign(s);
+          return null;
+        }
+        return originalOpen(url as any, target, features);
+      }) as typeof window.open;
+      w[guard] = true;
+    }
   }
 };
 

--- a/docker/jupyterhub/labextensions/hub-control-panel-same-tab/tsconfig.json
+++ b/docker/jupyterhub/labextensions/hub-control-panel-same-tab/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "outDir": "lib",
+    "rootDir": "src",
+    "strict": true,
+    "target": "es2018"
+  },
+  "include": ["src/**/*"]
+}
+

--- a/docker/jupyterhub/labextensions/hub-control-panel-same-tab/webpack.config.js
+++ b/docker/jupyterhub/labextensions/hub-control-panel-same-tab/webpack.config.js
@@ -1,24 +1,4 @@
-const path = require('path');
-
-module.exports = {
-  entry: './src/index.ts',
-  output: {
-    path: path.resolve(__dirname, 'lib'),
-    filename: 'index.js',
-    libraryTarget: 'umd'
-  },
-  resolve: {
-    extensions: ['.ts', '.js']
-  },
-  module: {
-    rules: [
-      {
-        test: /\.ts$/,
-        use: 'ts-loader',
-        exclude: /node_modules/
-      }
-    ]
-  }
-};
+// Not used anymore; we compile with TypeScript only
+module.exports = {};
 
 

--- a/docker/jupyterhub/labextensions/hub-control-panel-same-tab/webpack.config.js
+++ b/docker/jupyterhub/labextensions/hub-control-panel-same-tab/webpack.config.js
@@ -1,0 +1,24 @@
+const path = require('path');
+
+module.exports = {
+  entry: './src/index.ts',
+  output: {
+    path: path.resolve(__dirname, 'lib'),
+    filename: 'index.js',
+    libraryTarget: 'umd'
+  },
+  resolve: {
+    extensions: ['.ts', '.js']
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: 'ts-loader',
+        exclude: /node_modules/
+      }
+    ]
+  }
+};
+
+


### PR DESCRIPTION
This commit introduces a new labextension, 'hub-control-panel-same-tab', which allows the JupyterHub Control Panel to open in the same tab. It includes the necessary configuration files and updates the Dockerfile to install and build the extension. Additionally, it disables several unwanted JupyterLab extensions to streamline the user experience and rebuilds the Lab environment accordingly.