### PR TITLE
Update JupyterHub dependencies: bump uv version to 0.10.9 in requirem…

### DIFF
--- a/docker/jupyterhub/labextensions/hub-control-panel-same-tab/package.json
+++ b/docker/jupyterhub/labextensions/hub-control-panel-same-tab/package.json
@@ -13,19 +13,19 @@
     "clean": "rimraf lib build"
   },
   "devDependencies": {
-    "@jupyterlab/application": "4.5.3",
-    "@jupyterlab/mainmenu": "4.5.3",
+    "@jupyterlab/application": "4.5.4",
+    "@jupyterlab/mainmenu": "4.5.4",
     "@jupyterlab/builder": "^4.2.0",
     "@types/node": "^20.11.0",
-    "rimraf": "^5.0.5",
+    "rimraf": "^6.1.3",
     "ts-loader": "^9.5.1",
     "typescript": "^5.4.0",
     "webpack": "^5.91.0",
     "webpack-cli": "^5.1.4"
   },
   "peerDependencies": {
-    "@jupyterlab/application": ">=4.5.3 <5",
-    "@jupyterlab/mainmenu": ">=4.5.3 <5"
+    "@jupyterlab/application": ">=4.5.4 <5",
+    "@jupyterlab/mainmenu": ">=4.5.4 <5"
   },
   "main": "lib/index.js",
   "types": "lib/index.d.ts"

--- a/docker/jupyterhub/requirements.txt
+++ b/docker/jupyterhub/requirements.txt
@@ -3,4 +3,4 @@ nbstripout==0.9.1
 poetry==2.3.2
 cruft[pyproject]==2.16.0
 nox==2026.2.9
-uv<=0.10.4
+uv<=0.10.9

--- a/docker/jupyterhub/scripts/install-quarto.sh
+++ b/docker/jupyterhub/scripts/install-quarto.sh
@@ -19,12 +19,12 @@ rm -f /tmp/quarto.deb
 TINYTEX_DIR=/opt/TinyTeX
 mkdir -p "$TINYTEX_DIR"
 
-# Use the stable GitHub URL (no expiring signed URL)
-curl -fsSL https://github.com/rstudio/tinytex-releases/releases/download/daily/TinyTeX-1.tar.gz -o /tmp/TinyTeX.tar.gz
+# Use the explicit linux-x86_64 xz archive (the generic .tar.gz is actually xz-compressed)
+curl -fsSL https://github.com/rstudio/tinytex-releases/releases/download/daily/TinyTeX-1-linux-x86_64.tar.xz -o /tmp/TinyTeX.tar.xz
 
 # Extract directly into /opt/TinyTeX, stripping the top-level directory name
-tar -xzf /tmp/TinyTeX.tar.gz -C "$TINYTEX_DIR" --strip-components=1
-rm -f /tmp/TinyTeX.tar.gz
+tar -xJf /tmp/TinyTeX.tar.xz -C "$TINYTEX_DIR" --strip-components=1
+rm -f /tmp/TinyTeX.tar.xz
 chown -R root:root "$TINYTEX_DIR"
 
 # Detect platform-specific bin dir (e.g., x86_64-linux) and configure tlmgr


### PR DESCRIPTION
…ents.txt, upgrade JupyterLab application and mainmenu to 4.5.4 in hub-control-panel-same-tab package.json, and modify install-quarto.sh to use the explicit TinyTeX xz archive for installation.